### PR TITLE
Make --python-version optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ project repository does this:
 $ pip2conda
 grayskull
 packaging>=20.0
-python=3.9.*
 requests
 setuptools
 setuptools>=42

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -93,7 +93,6 @@ test =
     out = tmp_path / "out.txt"
     try:
         pip2conda_main(args=[
-            "--python-version", "9.9",
             "--project-dir", str(tmp_path),
             "--output", str(out),
             "--all",


### PR DESCRIPTION
This PR makes the `--python-version` option truly optional, so that, if not given, `python` is not included at all in the conda output.