### PR TITLE
Use tomli as the TOML API

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ requests
 setuptools
 setuptools>=42
 setuptools_scm>=3.4
-toml
+tomli
 tomli>=1.0.0
 wheel
 ```

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - grayskull
   - requests
   - setuptools
-  - toml
+  - tomli
   # docs
   - myst-parser
   - sphinx

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -18,7 +18,7 @@ from shutil import which
 
 import requests
 
-import toml
+import tomli
 
 import pkg_resources
 
@@ -192,7 +192,8 @@ def parse_build_requires(project_dir):
     project_dir = Path(project_dir)
     pyproject_toml = project_dir / "pyproject.toml"
     try:
-        ppt = toml.load(pyproject_toml)
+        with open(pyproject_toml, "rb") as file:
+            ppt = tomli.load(file)
     except FileNotFoundError:
         LOGGER.debug("  failed to read pyproject.toml, reading setup.cfg")
         setup_cfg = project_dir / "setup.cfg"

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 	grayskull
 	requests
 	setuptools
-	toml
+	tomli
 
 [options.extras_require]
 test =


### PR DESCRIPTION
This PR migrates the project to use `tomli` as the TOML API; since setuptools-scm requires it anyway this results in one less package to install most of the time.