### PR TITLE
Print a trailing newline in output files

### DIFF
--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -458,6 +458,6 @@ def main(args=None):
     # print output to file or stdout
     out = "\n".join(sorted(requirements))
     if args.output:
-        args.output.write_text(out)
+        args.output.write_text(out + "\n")
     else:
         print(out)


### PR DESCRIPTION
This PR modifies the tool to print a trailing newline into output files, mainly to make printing those files (`cat`) look better.