### PR TITLE
Update keyword arguments for subprocess.run

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Sphinx configuration for pip2conda
 """

--- a/pip2conda/__init__.py
+++ b/pip2conda/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Translate pip requirements into conda requirements
 """

--- a/pip2conda/__main__.py
+++ b/pip2conda/__main__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Module execution entry point for pip2conda
 """

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Parse setup.cfg for package requirements and print out a list of
 packages that can be installed using conda from the conda-forge channel.

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -292,7 +292,7 @@ def find_packages(requirements, use_mamba=True):
         cmd,
         check=False,
         stdout=subprocess.PIPE,
-        universal_newlines=True,  # rename to 'text' for python >=3.7
+        text=True,
     )
 
     if pfind.returncode:

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -1,4 +1,6 @@
-#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (C) Cardiff University (2022)
+# SPDX-License-Idenfitier: GPL-3.0-or-later
 
 """Parse setup.cfg for package requirements and print out a list of
 packages that can be installed using conda from the conda-forge channel.

--- a/pip2conda/tests/__init__.py
+++ b/pip2conda/tests/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for pip2conda
 """

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (C) Cardiff University (2022)
-# SPDX-License-Idenfitier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 """Tests for pip2conda
 """


### PR DESCRIPTION
This PR updates the call to `subprocess.run` to use the simplified `text` keyword argument introduced in Python 3.7.