### PR TITLE
Pin versions in test setup.cfg

### DIFF
--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -77,14 +77,14 @@ install_requires =
     reason="cannot find conda",
 )
 def test_end2end_real(tmp_path):
-    # write package information
+    # write package information (using exact pins for reproducibility)
     (tmp_path / "setup.cfg").write_text("""[options]
 setup_requires =
-    setuptools >= 42
-    setuptools_scm[toml] >= 3.4
+    setuptools ==62.1.0
+    setuptools_scm[toml] ==6.4.2
 install_requires =
-    gwpy
-    igwn-auth-utils[requests]
+    gwpy ==2.1.3
+    igwn-auth-utils[requests] ==0.2.2
     oldest-supported-numpy
 
 [options.extras_require]
@@ -107,9 +107,10 @@ test =
     # validate the result
     result = sorted(out.read_text().splitlines())
     expected = {
-        "gwpy",
-        "igwn-auth-utils",
-        "safe-netrc",
+        "gwpy==2.1.3",
+        "igwn-auth-utils==0.2.2",
+        "safe-netrc>=1.0.0",
         "setuptools>=42",
     }
     assert expected.issubset(result)
+    assert "oldest-supported-numpy" not in result


### PR DESCRIPTION
This MR updates the `setup.cfg` used in the tests to use exactly pinned versions so that the results are reproducible; this test was failing ATOW because `igwn-auth-utils[requests]` changed its internal requirements.