### PR TITLE
Support reading metadata from wheel

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@
 `pip2conda` is a tool to translate `pip`-style requirements into `conda`
 requirements.
 
-`pip2conda2` uses [`build`](https://github.com/pypa/build) to generate
-the metadata for a project, and then parses out the build and
-runtime requirements for the project - including unpackging extras and
-evaluating environment markers - before matching translating each requirement
+`pip2conda2` reads or generates the metadata for a project,
+evaluating the build (if possible) and runtime requirements - including unpackging
+extras and evaluating environment markers - before translating each requirement
 into a conda-forge requirement suitable for installation with `conda/mamba`.
 
 [![PyPI version](https://badge.fury.io/py/pip2conda.svg)](http://badge.fury.io/py/pip2conda)
@@ -36,7 +35,8 @@ python -m pip install pip2conda
 
 ## Basic Usage
 
-Just execute `pip2conda` from the base of your project directory.
+Just execute `pip2conda` from the base of your project directory, or point
+it at a wheel file for any project.
 For example, running `pip2conda` in the base directory for its own
 project repository does this:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,28 +1,2 @@
 .. include:: ../README.md
    :parser: myst_parser.sphinx_
-
-.. #########
-.. pip2conda
-.. #########
-
-.. .. image:: https://badge.fury.io/py/pip2conda.svg
-   :target: https://badge.fury.io/py/pip2conda
-   :alt: pip2conda PyPI release badge
-.. .. image:: https://img.shields.io/pypi/l/pip2conda.svg
-   :target: https://choosealicense.com/licenses/gpl-3.0/
-   :alt: pip2conda license
-
-.. ``pip2conda`` is a tool to translate `pip` requirements into `conda` requirements.
-
-.. It parses build requirements from ``pyproject.toml`` files, then runtime and
-.. extra requirements from ``setup.cfg``, including unpackging extras and
-.. evaluating environment markers, before matching translating each requirement
-.. into a conda-forge requirement suitable for installation with `conda/mamba`.
-
-.. ============
-.. Installation
-.. ============
-
-.. .. code-block:: bash
-
-    python -m pip install pip2conda

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -13,6 +13,8 @@ from unittest import mock
 
 import pytest
 
+from build import BuildException
+
 import requests
 
 from ..pip2conda import (
@@ -368,3 +370,12 @@ def test_wheel(tmp_path, whl):
         "requests",
         "ruamel.yaml",
     }
+
+
+def test_error(tmp_path):
+    """Test that giving no valid input results in an error.
+    """
+    with pytest.raises(BuildException):
+        pip2conda_main(args=[
+            "--project-dir", str(tmp_path),
+        ])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,4 +91,5 @@ addopts = "-r a"
 filterwarnings = [
 	"error",
 	"ignore:Support for::setuptools",
+	"ignore:.*pkg_resources",
 ]


### PR DESCRIPTION
This PR adds support for reading project metadata from a wheel (`.whl`) file, rather than generating it from a project directory.

This should enable using pip2conda to build environments for testing pre-built projects (e.g. in CI).