### PR TITLE
Add wheel as a project requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
 	"requests",
 	"ruamel.yaml",
 	"packaging",
+	"wheel",
 ]
 
 # dynamic properties set by tools:


### PR DESCRIPTION
This PR adds `wheel` as a formal runtime requirement; this should have been added in #24.