### PR TITLE
Simplify command quoting for logs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
     name: Flake8
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,19 +103,19 @@ jobs:
 
     - name: Upload test results
       if: always()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pytest-${{ matrix.os }}-${{ matrix.python-version }}
         path: pytest.xml
 
     - name: Upload tarball
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: tarball
         path: "*.tar.*"
 
     - name: Upload wheel(s)
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: wheel
         path: "*.whl"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
         fetch-depth: 0
 
     - name: Configure conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test
         miniforge-variant: Mambaforge

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,8 @@ jobs:
       uses: conda-incubator/setup-miniconda@v3
       with:
         activate-environment: test
-        miniforge-variant: Mambaforge
+        miniforge-version: latest
         python-version: ${{ matrix.python-version }}
-        use-mamba: true
-        # this is needed for caching to work properly:
-        use-only-tar-bz2: true
 
     - name: Conda info
       run: conda info --all
@@ -66,12 +63,12 @@ jobs:
     - name: Create distributions
       run: |
         # create isolated environment for build
-        mamba create -n build --quiet --yes \
+        conda create -n build --quiet --yes \
             python=${{ matrix.python-version }} \
             python-build \
         ;
         # create distributions
-        mamba run -n build python -m build . --sdist --wheel --outdir .
+        conda run -n build python -m build . --sdist --wheel --outdir .
 
     - name: Install this project with test extras
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,11 +108,11 @@ jobs:
     - name: Upload tarball
       uses: actions/upload-artifact@v4
       with:
-        name: tarball
+        name: sdist-${{ matrix.os }}-${{ matrix.python-version }}
         path: "*.tar.*"
 
     - name: Upload wheel(s)
       uses: actions/upload-artifact@v4
       with:
-        name: wheel
+        name: wheel-${{ matrix.os }}-${{ matrix.python-version }}
         path: "*.whl"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ on:
   push:
     branches:
       - main
-      - master
       - release/**
   pull_request:
     branches:
       - main
-      - master
       - release/**
+  schedule:
+    - cron: "0 0 * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Get source code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
       run: python -m coverage xml
 
     - name: Publish coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         files: ./coverage.xml
         flags: ${{ runner.os }},python${{ matrix.python-version }}

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -260,6 +260,7 @@ setup()
             "--project-dir", str(tmp_path),
             "--output", str(out),
             "--all",
+            "--disable-mamba",
             "--verbose",
             "--verbose",
         ])

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -363,10 +363,10 @@ def test_wheel(tmp_path, whl):
 
     # assert that we get what we should
     assert set(out.read_text().splitlines()) == {
-        "build",
         "grayskull>=1.0.0",
         "packaging",
         "python>=3.10",
+        "python-build",
         "requests",
         "ruamel.yaml",
     }


### PR DESCRIPTION
This PR fixes issues with newish conda/mamba versions where the annoying quoting used for printing the commands to the logger breaks the actual command. Thanks PowerShell.

~~The fix is to not use quotes in the command sent to subprocess, and use `shlex.join` for log output.~~

The fix is to escape the `>` characters on Windows, and use `shlex.join` to provide quotes for log output.