### PR TITLE
Use conda as default instead of mamba

### DIFF
--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -157,11 +157,7 @@ install_requires =
             "--python-version", "9.9",
             "--project-dir", str(tmp_path),
             "--output", str(out),
-            "--disable-mamba",
         ])
-
-        # validate that --disable-mamba worked
-        _run.assert_called_once()
 
     # validate the result
     assert out.read_text().splitlines() == [
@@ -260,7 +256,6 @@ setup()
             "--project-dir", str(tmp_path),
             "--output", str(out),
             "--all",
-            "--disable-mamba",
             "--verbose",
             "--verbose",
         ])


### PR DESCRIPTION
This PR modifies pip2conda to use `conda` as the default underlying executable, rather than `mamba`.

`conda` now defaults to using the `libmamba` solver, which provides most of the performance benefits of `mamba`, and `conda` has a more stable/useful JSON schema, especially for errors.

This PR replaces the `-M/--disable-mamba` command-line option with `-C/--conda` to provide the path to conda, which works with `--conda=mamba`.