### PR TITLE
Add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,38 @@
+# -- Build distributions and publish to PyPI
+
+name: Publish to PyPI
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  pypi:
+    name: Upload distributions to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pip2conda
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install build tools
+        run: python -m pip install build twine
+
+      - name: List installed
+        run: python -m pip list installed
+
+      - name: Build distributions
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1


### PR DESCRIPTION
This PR adds a PyPI publishing workflow to automatically deploy distributions to PyPI when releases are created.