### PR TITLE
Separate compound version specifiers

### DIFF
--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -1,7 +1,7 @@
 # Copyright (C) Cardiff University (2022)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""Parse setup.cfg for package requirements and print out a list of
+"""Parse a Python project for package requirements and print out a list of
 packages that can be installed using conda from the conda-forge channel.
 """
 

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -70,32 +70,40 @@ def load_conda_forge_name_map():
 
 
 def format_requirement(requirement, conda_forge_map=dict()):
-    """Format a (pip) Requirement as a conda dependency
+    """Format a (pip) Requirement as a conda dependency.
+
+    Complicated specifiers (with multiple conditions) are separated into
+    individual requirements which are yielded individually.
 
     Parameters
     ----------
     requirement : `packaging.requirements.Requirement`
-        the requirement to format
+        The requirement to format.
 
     conda_forge_map : `dict`
-        `(pypi_name, conda_forge_name)` mapping dictionary
+        `(pypi_name, conda_forge_name)` mapping dictionary.
 
-    Returns
+    Yields
     -------
     formatted : `str`
-        the formatted conda requirement
+        A formatted conda requirement.
 
     Examples
     --------
     >>> import packaging.requirements
     >>> req = packaging.requirements.Requirement.parse("htcondor >= 9.0.0")
-    >>> print(format_requirement(req))
-    'python-htcondor>=9.0.0'
+    >>> print(list(format_requirement(req)))
+    ['python-htcondor>=9.0.0']
+    >>> req = packaging.requirements.Requirement.parse("python-framel>=8.40.1,!=8.46.0")
+    >>> print(list(format_requirement(req)))
+    ['python-framel!=8.46.0', 'python-framel>=8.40.1']
     """
-    return (
-        conda_forge_map.get(requirement.name, requirement.name.lower())
-        + str(requirement.specifier)
-    ).strip()
+    name = conda_forge_map.get(requirement.name, requirement.name.lower())
+    if requirement.specifier:
+        for spec in requirement.specifier:
+            yield name + str(spec)
+    else:
+        yield name
 
 
 # -- python metadata parsing
@@ -304,7 +312,10 @@ def parse_requirements(
             conda_forge_map=conda_forge_map,
         )
         # format as 'name{>=version}'
-        yield format_requirement(req, conda_forge_map=conda_forge_map)
+        yield from format_requirement(
+            req,
+            conda_forge_map=conda_forge_map,
+        )
 
 
 # -- requirements.txt -------
@@ -395,8 +406,8 @@ def parse_all_requirements(
     if python_version:
         LOGGER.info(f"Using Python {python_version}")
         if not python_version.startswith((">", "<", "=")):
-            python_version = f"={python_version}.*"
-        yield f"python{python_version}"
+            python_version = f"=={python_version}.*"
+        yield from format_requirement(Requirement(f"python{python_version}"))
 
     # then build requirements
     if not skip_build_requires:

--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -74,7 +74,7 @@ def format_requirement(requirement, conda_forge_map=dict()):
 
     Parameters
     ----------
-    requirement : `pkg_resources.Requirement`
+    requirement : `packaging.requirements.Requirement`
         the requirement to format
 
     conda_forge_map : `dict`
@@ -87,8 +87,8 @@ def format_requirement(requirement, conda_forge_map=dict()):
 
     Examples
     --------
-    >>> import pkg_resources
-    >>> req = pkg_resources.Requirement.parse("htcondor >= 9.0.0")
+    >>> import packaging.requirements
+    >>> req = packaging.requirements.Requirement.parse("htcondor >= 9.0.0")
     >>> print(format_requirement(req))
     'python-htcondor>=9.0.0'
     """
@@ -208,7 +208,7 @@ def parse_req_extras(req, environment=None, conda_forge_map=dict()):
 
     Parameters
     ----------
-    req : `pkg_resources.Requirement`
+    req : `packaging.requirements.Requirement`
         the requirement to format
 
     conda_forge_map : `dict`
@@ -280,7 +280,7 @@ def parse_requirements(
 
     Yields
     ------
-    spec : `pkg_resources.Requirement`
+    spec : `packaging.requirements.Requirement`
         a formatted requirement for each line
     """
     for entry in requirements:

--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -161,7 +161,7 @@ install_requires =
         "a",
         "c>=2.0",
         "e>=2.0",
-        "python=9.9.*",
+        "python==9.9.*",
     ]
 
 
@@ -207,7 +207,7 @@ test = [
         "numpy>=1.20.0",
         "pytest",
         "pytest-cov>=2.0.0",
-        "python=3.11.*",
+        "python==3.11.*",
         "scipy",
         "setuptools",
     }
@@ -339,7 +339,8 @@ test = [ "pytest" ]
         "h5py>=2.10.0",
         "poetry-core>=1.0.0",
         "pytest",
-        "python>=3.10,<4.0",
+        "python>=3.10",
+        "python<4.0",
     }
 
 


### PR DESCRIPTION
This PR modifies the requirements parsing to separate out compound version specifiers (e.g. `python>=3.12,<4.0`) into individual requirements for the named package (e.g. `['python>=3.12', 'python<4.0']`). This makes is easier to format the requirements for passing through subprocess to `conda`, especially on Windows.