### PR TITLE
Remove unused call to json.loads

### DIFF
--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -478,17 +478,12 @@ def find_packages(requirements, conda=CONDA):
         cmdstr = shlex.join(cmd)
 
     LOGGER.debug(f"$ {cmdstr}")
-    pfind = subprocess.run(
+    return subprocess.run(
         cmd,
         check=False,
         stdout=subprocess.PIPE,
         text=True,
     )
-
-    if pfind.returncode:
-        json.loads(pfind.stdout)
-
-    return pfind
 
 
 def filter_requirements(requirements, conda=CONDA):


### PR DESCRIPTION
This PR removes an apparently unused call to `json.loads` to parse the output of `conda create`.