### PR TITLE
Handle posix signal termination for conda create

### DIFF
--- a/pip2conda/pip2conda.py
+++ b/pip2conda/pip2conda.py
@@ -501,6 +501,8 @@ def filter_requirements(requirements, conda=CONDA):
     LOGGER.info(f"Finding packages with {exe}")
     pfind = find_packages(requirements, conda=conda)
 
+    if pfind.returncode < 0:  # killed with signal
+        return pfind.check_returncode()  # raises
     if pfind.returncode:  # something went wrong
         # parse the JSON report
         report = json.loads(pfind.stdout)


### PR DESCRIPTION
This MR patches `filter_requirements` to handle a negative return code from `conda check`, which is indicative of the process being terminated by a signal. In these cases there will not be any output to parse, so we should exit early.