### PR TITLE
Fix safe-netrc version reference

### DIFF
--- a/pip2conda/tests/test_pip2conda.py
+++ b/pip2conda/tests/test_pip2conda.py
@@ -264,7 +264,7 @@ setup()
     expected = {
         "gwpy==2.1.3",
         "igwn-auth-utils==0.2.2",
-        "safe-netrc>=1.0.0",
+        "safe-netrc>=1.0",
         "setuptools==62.1.0",
     }
     assert expected.issubset(result)


### PR DESCRIPTION
This MR fixes a test failure by updating the version reference for `safe-netrc` as exposed as a requirement of `igwn-auth-utils`.