### PR TITLE
Add README note about requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,12 @@ setuptools-scm>=3.4.3
 setuptools>=61.0
 wheel
 ```
+
+## Converting requirements.txt
+
+To convert an existing `requirements.txt` file into a conda environment.txt file,
+use the `-r/--requirements` option:
+
+```shell
+pip2conda -r ./requirements.txt
+```


### PR DESCRIPTION
This PR closes #23 by adding a note to `README.md` about parsing `requirements.txt` files.